### PR TITLE
feat(header): 헤더 구성 atom 구현 (#734)

### DIFF
--- a/src/client/.storybook/preview.js
+++ b/src/client/.storybook/preview.js
@@ -1,9 +1,11 @@
+import "../styles/global.css";
+
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
-    },
-  },
-}
+	actions: { argTypesRegex: "^on[A-Z].*" },
+	controls: {
+		matchers: {
+			color: /(background|color)$/i,
+			date: /Date$/,
+		},
+	},
+};

--- a/src/client/src/components/atoms/HeaderMainItem/index.stories.tsx
+++ b/src/client/src/components/atoms/HeaderMainItem/index.stories.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import HeaderMainItem from ".";
+
+export default {
+	title: "atoms/HeaderMainItem",
+	component: HeaderMainItem,
+	args: {
+		onClick: action("Change Link to /shop"),
+	},
+} as ComponentMeta<typeof HeaderMainItem>;
+
+const Template: ComponentStory<typeof HeaderMainItem> = (args) => (
+	<HeaderMainItem {...args}>{args.children}</HeaderMainItem>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	children: "SHOP",
+};

--- a/src/client/src/components/atoms/HeaderMainItem/index.tsx
+++ b/src/client/src/components/atoms/HeaderMainItem/index.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import React, { FunctionComponent } from "react";
+
+import colors from "../../../colors/color";
+
+type HeaderMainItemProps = {
+	children: React.ReactNode;
+	onClick?: React.MouseEventHandler<HTMLLIElement>;
+};
+
+const HeaderMainItem: FunctionComponent<HeaderMainItemProps> = (props) => {
+	const { children, onClick } = props;
+	return <StyledList onClick={onClick}>{children}</StyledList>;
+};
+
+export default HeaderMainItem;
+
+const StyledList = styled.li`
+	list-style: none;
+	font-size: 15px;
+	cursor: pointer;
+`;

--- a/src/client/src/components/atoms/HeaderTopItem/index.stories.tsx
+++ b/src/client/src/components/atoms/HeaderTopItem/index.stories.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import HeaderTopItem from ".";
+
+export default {
+	title: "atoms/HeaderTopItem",
+	component: HeaderTopItem,
+	args: {
+		onClick: action("Change Link to /wish"),
+	},
+} as ComponentMeta<typeof HeaderTopItem>;
+
+const Template: ComponentStory<typeof HeaderTopItem> = (args) => (
+	<HeaderTopItem {...args}>{args.children}</HeaderTopItem>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	children: "관심상품",
+};

--- a/src/client/src/components/atoms/HeaderTopItem/index.tsx
+++ b/src/client/src/components/atoms/HeaderTopItem/index.tsx
@@ -1,0 +1,23 @@
+import styled from "@emotion/styled";
+import React, { FunctionComponent } from "react";
+
+import colors from "../../../colors/color";
+
+type HeaderTopItemProps = {
+	children: React.ReactNode;
+	onClick?: React.MouseEventHandler<HTMLLIElement>;
+};
+
+const HeaderTopItem: FunctionComponent<HeaderTopItemProps> = (props) => {
+	const { children, onClick } = props;
+	return <StyledList onClick={onClick}>{children}</StyledList>;
+};
+
+export default HeaderTopItem;
+
+const StyledList = styled.li`
+	list-style: none;
+	color: ${colors.buttonTextColors.primary.default};
+	font-size: 12px;
+	cursor: pointer;
+`;

--- a/src/client/src/pages/index.tsx
+++ b/src/client/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent } from "react";
 
 const Home: FunctionComponent = () => {
-	return <h1>Next JS</h1>;
+	return <h1>Next JS 테스팅</h1>;
 };
 
 export default Home;

--- a/src/client/styles/global.css
+++ b/src/client/styles/global.css
@@ -1,0 +1,15 @@
+html,
+body {
+	font-family: "Noto Sans KR", sans-serif;
+	padding: 0;
+	margin: 0;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+a {
+	color: black;
+	text-decoration: none;
+}


### PR DESCRIPTION
### Detail

![image](https://user-images.githubusercontent.com/52649378/148380675-82a8aa61-a503-4d05-801d-c92b2aeee0fc.png)

- 위 사진 우측에 보이는 고객센터 (`HeaderTopItem') 과 그 아래 STYLE(`HeaderMainItem`) 구현.
- 추후 바인딩 될 onClick 이벤트 바인딩.
- storybook의 `action` 기능 추가.