### PR TITLE
feat(image): 상품 이미지 컴포넌트 구성. (#733)

### DIFF
--- a/src/client/.storybook/preview.js
+++ b/src/client/.storybook/preview.js
@@ -1,4 +1,10 @@
 import "../styles/global.css";
+import * as nextImage from "next/image";
+
+Object.defineProperty(nextImage, "default", {
+	configurable: true,
+	value: (props) => <img {...props} />,
+});
 
 export const parameters = {
 	actions: { argTypesRegex: "^on[A-Z].*" },

--- a/src/client/next.config.js
+++ b/src/client/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	images: {
+		domains: ["kream-phinf.pstatic.net"],
+	},
+};

--- a/src/client/src/components/atoms/ProductImage/index.stories.tsx
+++ b/src/client/src/components/atoms/ProductImage/index.stories.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import ProductImage from "./";
+
+export default {
+	title: "atoms/ProductImage",
+	component: ProductImage,
+} as ComponentMeta<typeof ProductImage>;
+
+const Template: ComponentStory<typeof ProductImage> = (args) => (
+	<ProductImage {...args} />
+);
+
+export const HomeImage = Template.bind({});
+HomeImage.args = {
+	src: "https://kream-phinf.pstatic.net/MjAyMTA3MjhfMjIg/MDAxNjI3NDQxMDA1NjE5.HOgIYywGZaaBJDqUzx2OnX9HAxoOWPvuWHqUn_LZGcgg.VYIuOfA5_GgjBGRowv6dmQuAOPtUvmAxbGpOyUCOCtYg.PNG/p_9d8ed1a74d2540ab9842e63363607bf4.png?type=m",
+	category: "home",
+	backgroundColor: "rgb(235, 240, 245)",
+};
+
+export const ShopImage = Template.bind({});
+ShopImage.args = {
+	src: "https://kream-phinf.pstatic.net/MjAyMTExMTZfMzkg/MDAxNjM3MDQzMzM0MzUz.94K4SoFB9IWLnLRh2iUXjWN0s53ADBEfhwIQQVC_kbAg.4Xl3LXELbnhDdMl8Vz0RdUF7JdQzk_LYyhOHIDvIQUgg.PNG/a_d38d4d9403c34c7c9f4f52bf2ce4f649.png?type=m",
+	category: "shop",
+	backgroundColor: "rgb(246, 238, 237)",
+};
+
+export const ProductItemImage = Template.bind({});
+ProductItemImage.args = {
+	src: "https://kream-phinf.pstatic.net/MjAyMTEyMTBfMjQ4/MDAxNjM5MTEyMTE4ODk3.E5xSNEGfpoeBSUdiEb1TiK0xB8pQZ2sbsmKwir2X0H0g.N-57P9OD7r27nsWNs_0AwgF6CJAO7GrokL22BCeS7QUg.PNG/a_40f9f33ce83747cba477269413bee1f0.png?type=m",
+	category: "products",
+	backgroundColor: "rgb(241, 241, 234)",
+};

--- a/src/client/src/components/atoms/ProductImage/index.tsx
+++ b/src/client/src/components/atoms/ProductImage/index.tsx
@@ -1,0 +1,48 @@
+import React, { CSSProperties, FunctionComponent } from "react";
+import Image from "next/image";
+import styled from "@emotion/styled";
+
+type ProductImageProps = {
+	backgroundColor: string;
+	src: string;
+	category: string;
+	style?: CSSProperties;
+};
+
+const imageSizes = {
+	home: "81.5",
+	shop: "81.5",
+	products: "560",
+};
+
+const ProductImage: FunctionComponent<ProductImageProps> = (props) => {
+	const { backgroundColor, category, src } = props;
+	return (
+		<ImageWrapper category={category} backgroundColor={backgroundColor}>
+			<StyledImage category={category} src={src} alt={src} />
+		</ImageWrapper>
+	);
+};
+
+export default ProductImage;
+
+const ImageWrapper = styled.div<{ category: string; backgroundColor: string }>`
+	background-color: ${({ backgroundColor }) => backgroundColor};
+	border-radius: 8px;
+	position: relative;
+	width: ${({ category }) => (category === "products" ? `560px` : `25%`)};
+	padding-top: ${({ category }) => (category === "products" ? `560px` : `25%`)};
+	overflow: hidden;
+`;
+
+const StyledImage = styled(Image)<{ category: string }>`
+	width: ${({ category }) =>
+		category === "products"
+			? `${imageSizes[category]}px`
+			: `${imageSizes[category]}%`};
+	height: auto;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+`;


### PR DESCRIPTION
### Detail

- 상품 이미지를 보여주는 이미지 컴포넌트를 작성했습니다.
- 3가지 종류로 나누어 렌더링합니다. 
  - home, shop, products 의 3가지 상태로 렌더링합니다.
- 이미지의 출처 (`src`), 그리고 배경색은 `props` 로 받아 렌더링합니다.

[이곳](https://deploy-preview-5--lemondade-storybook.netlify.app)을 눌러 확인하실수 있습니다.