### PR TITLE
feat(input): input 태그 컴포넌트 작성. (#839)

### DIFF
--- a/src/client/emotion.d.ts
+++ b/src/client/emotion.d.ts
@@ -4,6 +4,7 @@ declare module "@emotion/react" {
 	export interface Color {
 		colors: {
 			default: string;
+			error: string;
 		};
 		buttonTextColors: {
 			primary: {

--- a/src/client/src/colors/color.ts
+++ b/src/client/src/colors/color.ts
@@ -3,6 +3,7 @@ import { Color } from "@emotion/react";
 const colors: Color = {
 	colors: {
 		default: "#222222",
+		error: "#f15746",
 	},
 	buttonTextColors: {
 		primary: {

--- a/src/client/src/components/atoms/Input/index.stories.tsx
+++ b/src/client/src/components/atoms/Input/index.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import Input from ".";
+
+export default {
+	title: "atoms/Input",
+	component: Input,
+} as ComponentMeta<typeof Input>;
+
+const Template: ComponentStory<typeof Input> = (args) => (
+	<Input {...args}>{args.children}</Input>
+);
+
+export const Email = Template.bind({});
+Email.args = {
+	category: "email",
+	content: "이메일 주소",
+};
+
+export const Password = Template.bind({});
+Password.args = {
+	category: "password",
+	content: "비밀번호",
+};
+
+export const Phone = Template.bind({});
+Phone.args = {
+	category: "phone",
+	content: "휴대폰 번호",
+};
+
+export const Error = Template.bind({});
+Error.args = {
+	category: "email",
+	error: true,
+};

--- a/src/client/src/components/atoms/Input/index.tsx
+++ b/src/client/src/components/atoms/Input/index.tsx
@@ -1,0 +1,78 @@
+import React, { FunctionComponent } from "react";
+import styled from "@emotion/styled";
+
+import colors from "colors/color";
+import { css } from "@emotion/react";
+
+type InputProps = {
+	category: string;
+	error?: boolean;
+};
+
+const placeholders = {
+	email: "예) cream@cream.co.kr",
+	password: "영문, 숫자, 특수문자 조합 8 ~ 16자",
+	phone: "가입하신 휴대폰 번호",
+};
+
+const fieldTitle = {
+	email: "이메일 주소",
+	password: "비밀번호",
+	phone: "핸드폰 번호",
+};
+
+const Input: FunctionComponent<InputProps> = (props) => {
+	const { category, error = false } = props;
+	const placeholder = placeholders[category];
+	return (
+		<>
+			<StyledInputTitle error={error}>{fieldTitle[category]}</StyledInputTitle>
+			<StyledInput type={category} error={error} placeholder={placeholder} />
+			{error && (
+				<ErrorMsg>🤔 {fieldTitle[category]} 형식을 확인해주세요!</ErrorMsg>
+			)}
+		</>
+	);
+};
+
+export default Input;
+
+const StyledInputTitle = styled.h3<{ error: boolean }>`
+	font-size: 13px;
+	letter-spacing: -0.07px;
+	line-height: 18px;
+	color: ${({ error }) =>
+		error ? `${colors.colors.error}` : `${colors.colors.default}`};
+`;
+
+const StyledInput = styled.input<{ error: boolean }>`
+	width: 400px;
+	outline: 0;
+	border-width: 0 0 1px;
+	height: 38px;
+	line-height: 22px;
+	font-size: 15px;
+	border-color: ${colors.borderColors.primary.disabled};
+	:focus {
+		border-color: ${colors.borderColors.primary.active};
+	}
+	::placeholder {
+		color: ${colors.borderColors.primary.default};
+	}
+	${({ error }) =>
+		error &&
+		css`
+			border-color: ${colors.colors.error};
+			:focus {
+				border-color: ${colors.colors.error};
+			}
+		`}
+`;
+
+const ErrorMsg = styled.p`
+	color: ${colors.colors.error};
+	display: block;
+	position: absolute;
+	line-height: 16px;
+	font-size: 11px;
+`;


### PR DESCRIPTION
### Detail

- `input` 태그 컴포넌트 작성.
- 3가지 input 태그가 렌더링 되도록 작성.

  - `email`, `password`, `phone` 으로 3가지로 나뉨.

- Error 가 났을때도 동일 컴포넌트에서 렌더링 될 수 있도록 작성.

  - 에러 발생시에도 email`, `password`, `phone` 으로 3가지로 나뉠 수 있도록 작성함.

[여기](https://deploy-preview-13--lemondade-storybook.netlify.app/?path=/story/atoms-input--email)에서 확인 하실 수 있습니다.