### PR TITLE
feat(headerTop): 첫번째 GNB 구현.

### DIFF
--- a/src/client/emotion.d.ts
+++ b/src/client/emotion.d.ts
@@ -7,6 +7,7 @@ declare module "@emotion/react" {
 			error: string;
 			plain: string;
 			tag: string;
+			border: string;
 		};
 		buttonTextColors: {
 			primary: {

--- a/src/client/next.config.js
+++ b/src/client/next.config.js
@@ -2,4 +2,7 @@ module.exports = {
 	images: {
 		domains: ["kream-phinf.pstatic.net"],
 	},
+	env: {
+		END_POINT: "www.naver.com/",
+	},
 };

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -14,6 +14,7 @@
 		"@emotion/react": "^11.7.1",
 		"@emotion/styled": "^11.6.0",
 		"@svgr/webpack": "^6.1.2",
+		"axios": "^0.24.0",
 		"babel-plugin-inline-react-svg": "^2.0.1",
 		"next": "^12.0.7",
 		"react": "^17.0.2",

--- a/src/client/src/colors/color.ts
+++ b/src/client/src/colors/color.ts
@@ -6,6 +6,7 @@ const colors: Color = {
 		error: "#f15746",
 		plain: "#000",
 		tag: "rgba(34,34,34,.5)",
+		border: "#e5e5e5",
 	},
 	buttonTextColors: {
 		primary: {

--- a/src/client/src/components/organisms/HeaderTop/index.stories.tsx
+++ b/src/client/src/components/organisms/HeaderTop/index.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
 
 import HeaderTop from ".";
 

--- a/src/client/src/components/organisms/HeaderTop/index.stories.tsx
+++ b/src/client/src/components/organisms/HeaderTop/index.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+
+import HeaderTop from ".";
+
+export default {
+	title: "organisms/HeaderTop",
+	component: HeaderTop,
+} as ComponentMeta<typeof HeaderTop>;
+
+const Template: ComponentStory<typeof HeaderTop> = (args) => (
+	<HeaderTop {...args}>{args.children}</HeaderTop>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/client/src/components/organisms/HeaderTop/index.tsx
+++ b/src/client/src/components/organisms/HeaderTop/index.tsx
@@ -1,0 +1,99 @@
+import React, {
+	FunctionComponent,
+	useCallback,
+	useEffect,
+	useState,
+} from "react";
+import styled from "@emotion/styled";
+
+import HeaderTopItem from "components/atoms/HeaderTopItem";
+import colors from "colors/color";
+import Link from "next/link";
+import { validateUser } from "utils/user";
+import { useRouter } from "next/router";
+
+const HeaderTop: FunctionComponent = () => {
+	const router = useRouter();
+
+	const [islogin, setIsLogin] = useState<boolean>(false);
+
+	const onLogout = () => {
+		window.localStorage.removeItem("creamToken");
+		router.push("/");
+	};
+
+	const getCurrentUser = useCallback(async () => {
+		try {
+			const res = await validateUser();
+			if (res) {
+				setIsLogin(true);
+			}
+			// will add userContext
+		} catch (e) {
+			setIsLogin(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		getCurrentUser();
+	}, [getCurrentUser]);
+
+	return (
+		<HeaderTopWrapper>
+			<Link href={"https://github.com/SG-LEMONADE/CREAM"}>
+				<a>
+					<HeaderTopItem>About CREAM</HeaderTopItem>
+				</a>
+			</Link>
+			{!islogin ? (
+				<Link href={"/login"}>
+					<a>
+						<HeaderTopItem>관심상품</HeaderTopItem>
+					</a>
+				</Link>
+			) : (
+				<Link href={"/my/wish"}>
+					<a>
+						<HeaderTopItem>관심상품</HeaderTopItem>
+					</a>
+				</Link>
+			)}
+			{!islogin ? (
+				<Link href={"/login"}>
+					<a>
+						<HeaderTopItem>관심상품</HeaderTopItem>
+					</a>
+				</Link>
+			) : (
+				<Link href={"/my"}>
+					<a>
+						<HeaderTopItem>마이페이지</HeaderTopItem>
+					</a>
+				</Link>
+			)}
+			{!islogin ? (
+				<Link href={"/login"}>
+					<a>
+						<HeaderTopItem>로그인</HeaderTopItem>
+					</a>
+				</Link>
+			) : (
+				<HeaderTopItem onClick={onLogout}>로그아웃</HeaderTopItem>
+			)}
+		</HeaderTopWrapper>
+	);
+};
+
+export default HeaderTop;
+
+const HeaderTopWrapper = styled.header`
+	display: flex;
+	padding: 8px 40px;
+	align-items: center;
+	justify-content: flex-end;
+	margin-left: auto;
+	> a {
+		margin-left: 24px;
+	}
+	border-bottom: 1px solid ${colors.colors.border};
+`;

--- a/src/client/src/components/templates/Home/index.tsx
+++ b/src/client/src/components/templates/Home/index.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from "react";
+import styled from "@emotion/styled";
+
+type HomeProps = {
+	header: React.ReactNode;
+	children: React.ReactNode;
+	footer?: React.ReactNode;
+};
+
+const Home: FunctionComponent<HomeProps> = (props) => {
+	const { header, children, footer } = props;
+	return (
+		<StyledHomeWrapper>
+			{header && <>{header}</>}
+			<StyledContent>{children}</StyledContent>
+			{footer && <>{footer}</>}
+		</StyledHomeWrapper>
+	);
+};
+
+export default Home;
+
+const StyledHomeWrapper = styled.div``;
+
+const StyledContent = styled.main`
+	flex: 1;
+`;

--- a/src/client/src/components/templates/HomeTemplate/index.stories.tsx
+++ b/src/client/src/components/templates/HomeTemplate/index.stories.tsx
@@ -5,7 +5,7 @@ import HomeTemplate from ".";
 import HeaderTop from "components/organisms/HeaderTop";
 
 export default {
-	title: "templates/Home",
+	title: "templates/HomeTemplate",
 	component: HomeTemplate,
 } as ComponentMeta<typeof HomeTemplate>;
 

--- a/src/client/src/components/templates/HomeTemplate/index.stories.tsx
+++ b/src/client/src/components/templates/HomeTemplate/index.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import HomeTemplate from ".";
+import HeaderTop from "components/organisms/HeaderTop";
+
+export default {
+	title: "templates/Home",
+	component: HomeTemplate,
+} as ComponentMeta<typeof HomeTemplate>;
+
+const Template: ComponentStory<typeof HomeTemplate> = (args) => (
+	<HomeTemplate {...args}>{args.children}</HomeTemplate>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	header: <HeaderTop />,
+	children: <h1>Home screen</h1>,
+};

--- a/src/client/src/components/templates/HomeTemplate/index.tsx
+++ b/src/client/src/components/templates/HomeTemplate/index.tsx
@@ -1,13 +1,13 @@
 import React, { FunctionComponent } from "react";
 import styled from "@emotion/styled";
 
-type HomeProps = {
+type HomeTemplateProps = {
 	header: React.ReactNode;
 	children: React.ReactNode;
 	footer?: React.ReactNode;
 };
 
-const Home: FunctionComponent<HomeProps> = (props) => {
+const HomeTemplate: FunctionComponent<HomeTemplateProps> = (props) => {
 	const { header, children, footer } = props;
 	return (
 		<StyledHomeWrapper>
@@ -18,7 +18,7 @@ const Home: FunctionComponent<HomeProps> = (props) => {
 	);
 };
 
-export default Home;
+export default HomeTemplate;
 
 const StyledHomeWrapper = styled.div``;
 

--- a/src/client/src/lib/customAxios.ts
+++ b/src/client/src/lib/customAxios.ts
@@ -1,0 +1,9 @@
+import axios, { AxiosInstance } from "axios";
+import { getToken } from "utils/token";
+
+export const customAxios: AxiosInstance = axios.create({
+	baseURL: `${process.env.END_POINT}`,
+	headers: {
+		Authorization: `Bearer ${getToken()}`,
+	},
+});

--- a/src/client/src/pages/_app.tsx
+++ b/src/client/src/pages/_app.tsx
@@ -1,0 +1,5 @@
+import "../../styles/global.css";
+
+export default function App({ Component, pageProps }) {
+	return <Component {...pageProps} />;
+}

--- a/src/client/src/pages/index.tsx
+++ b/src/client/src/pages/index.tsx
@@ -1,7 +1,14 @@
 import React, { FunctionComponent } from "react";
 
-const Home: FunctionComponent = () => {
-	return <h1>Next JS 테스팅</h1>;
+import Home from "components/templates/Home";
+import HeaderTop from "components/organisms/HeaderTop";
+
+const home: FunctionComponent = () => {
+	return (
+		<Home header={<HeaderTop />}>
+			<h1>Next JS 테스팅</h1>
+		</Home>
+	);
 };
 
-export default Home;
+export default home;

--- a/src/client/src/utils/token.ts
+++ b/src/client/src/utils/token.ts
@@ -1,0 +1,10 @@
+export const getToken = () => {
+	return (
+		typeof window !== "undefined" && window.localStorage.getItem("creamToken")
+	);
+};
+
+export const setToken = (token: string) => {
+	typeof window !== "undefined" &&
+		window.localStorage.setItem("creamToken", token);
+};

--- a/src/client/src/utils/user.ts
+++ b/src/client/src/utils/user.ts
@@ -1,0 +1,18 @@
+import { customAxios } from "lib/customAxios";
+
+export const validateUser = async (): Promise<number> => {
+	const token = window.localStorage.getItem("creamToken");
+	if (!token) {
+		return;
+	}
+	try {
+		const res = await customAxios.post("/users/validate");
+		if (res.data === null) {
+			return 1;
+		} else {
+			return;
+		}
+	} catch (e) {
+		return;
+	}
+};

--- a/src/client/yarn.lock
+++ b/src/client/yarn.lock
@@ -4493,6 +4493,13 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
+axios@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
+  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+  dependencies:
+    follow-redirects "^1.14.4"
+
 babel-loader@^8.0.0, babel-loader@^8.2.3:
   version "8.2.3"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.3.tgz#8986b40f1a64cacfcb4b8429320085ef68b1342d"
@@ -6785,6 +6792,11 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@^1.14.4:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
+  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### Detail

- 화면 상 맨 위 GNB 구현.

  - 유저의 로그인 여부에 따라 보이는 것이 달라야 함.

  - `api` 통신 추가. 

  - ![image](https://user-images.githubusercontent.com/52649378/149320853-00d901dd-a3bd-4a3f-b394-acc367f5bb54.png)
  - 위 코드로 인해 모든 화면상에서 유저의 로그인 유지 여부를 알 수 있음.

- ![image](https://user-images.githubusercontent.com/52649378/149320977-c9445213-5f23-4ead-8588-7d297c2ff63a.png)

  - `Axios` default 모듈 작성.
  - 토큰을 자동으로 설정해주어 코드량 감소.

- ![image](https://user-images.githubusercontent.com/52649378/149321096-1da73c7f-f1e2-42ea-adce-ddde5b96a9be.png)

  - @Deserve82 님께서 공유해주신 주소로 `POST` 요청 날림.
