### PR TITLE
feat(banner): 배너 낱개 이미지 생성. (#847)

### DIFF
--- a/src/client/src/components/atoms/Banner/index.stories.tsx
+++ b/src/client/src/components/atoms/Banner/index.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import BannerImage from ".";
+
+export default {
+	title: "atoms/BannerImage",
+	component: BannerImage,
+} as ComponentMeta<typeof BannerImage>;
+
+const Template: ComponentStory<typeof BannerImage> = (args) => (
+	<BannerImage {...args}>{args.children}</BannerImage>
+);
+
+export const Big = Template.bind({});
+Big.args = {
+	bgColor: "rgb(185, 145, 237)",
+	category: "big",
+	src: "https://kream-phinf.pstatic.net/MjAyMjAxMDdfMjE1/MDAxNjQxNTQ0MjY5MjMx.sh8EkefwZTj77UkKMisov1eV3KGnAmSQjd4Nuc6TtaEg.-xyxjm-rcxWLSQL4COdO6WfsEsxnMKjf0s8INeazuEwg.PNG/a_17eb39b3028c4925a156ccde317e851e.png?type=m_2560",
+};
+
+export const Small = Template.bind({});
+Small.args = {
+	bgColor: "#4a4a4a",
+	category: "small",
+	src: "https://kream-phinf.pstatic.net/MjAyMjAxMTFfMjA1/MDAxNjQxODkwNjY5NDI5.6NPmF_WbPm9sX5lW9BE2PcQlkMRAvFxDy7bryYVsDc4g.8YA62__XKcpRvDp-m3k22k1ib0Larluka04T22wL2Ycg.PNG/a_586211b5374344ffa601d2379799d0f0.png",
+};

--- a/src/client/src/components/atoms/Banner/index.tsx
+++ b/src/client/src/components/atoms/Banner/index.tsx
@@ -1,0 +1,51 @@
+import React, { FunctionComponent } from "react";
+import Image from "next/image";
+
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import { useRouter } from "next/router";
+
+type BannerProps = {
+	links?: string;
+	bgColor: string;
+	category: "big" | "small";
+	readonly src: string;
+};
+
+const BannerImage: FunctionComponent<BannerProps> = (props) => {
+	const { links, bgColor, category, src } = props;
+	const router = useRouter();
+	return (
+		<StyledBannerWrapper
+			onClick={() => router.push(`/${links}`)}
+			category={category}
+			bgColor={bgColor}
+		>
+			<StyledImage category={category} src={src} alt={src} />
+		</StyledBannerWrapper>
+	);
+};
+
+export default BannerImage;
+
+const StyledBannerWrapper = styled.div<{ category: string; bgColor: string }>`
+	overflow: hidden;
+	vertical-align: top;
+	cursor: pointer;
+	height: ${({ category }) => (category === "big" ? `480px;` : `100px`)};
+	text-align: center;
+	background-color: ${({ bgColor }) => bgColor};
+	${({ category }) =>
+		category === "small" &&
+		css`
+			max-width: 1200px;
+		`}
+`;
+
+const StyledImage = styled(Image)<{ category: string }>`
+	top: 0;
+	width: auto;
+	height: 100%;
+	max-height: ${({ category }) => (category === "big" ? `480px;` : `100px`)};
+	max-width: 100%;
+`;

--- a/src/client/src/components/atoms/Banner/index.tsx
+++ b/src/client/src/components/atoms/Banner/index.tsx
@@ -32,7 +32,7 @@ const StyledBannerWrapper = styled.div<{ category: string; bgColor: string }>`
 	overflow: hidden;
 	vertical-align: top;
 	cursor: pointer;
-	height: ${({ category }) => (category === "big" ? `480px;` : `100px`)};
+	max-height: ${({ category }) => (category === "big" ? `480px;` : `100px`)};
 	text-align: center;
 	background-color: ${({ bgColor }) => bgColor};
 	${({ category }) =>
@@ -45,7 +45,6 @@ const StyledBannerWrapper = styled.div<{ category: string; bgColor: string }>`
 const StyledImage = styled(Image)<{ category: string }>`
 	top: 0;
 	width: auto;
-	height: 100%;
 	max-height: ${({ category }) => (category === "big" ? `480px;` : `100px`)};
 	max-width: 100%;
 `;

--- a/src/client/src/components/organisms/HeaderMain/index.tsx
+++ b/src/client/src/components/organisms/HeaderMain/index.tsx
@@ -11,7 +11,11 @@ import styled from "@emotion/styled";
 const HeaderMain: FunctionComponent = () => {
 	return (
 		<HeaderMainWrapper>
-			<Logo category={"Logo"} />
+			<Link href={"/"}>
+				<a>
+					<Logo category={"Logo"} />
+				</a>
+			</Link>
 			<StyledGNBArea>
 				<HeaderMainItem
 					onClick={() => alert("Coming soon...")}
@@ -42,7 +46,10 @@ const HeaderMainWrapper = styled.header`
 	min-width: 320px;
 	align-items: center;
 	border-bottom: 1px solid ${colors.colors.border};
-	> svg:first-of-type {
+	svg:first-child {
+		padding-top: 15px;
+	}
+	first-of-type {
 		padding-top: 15px;
 	}
 `;


### PR DESCRIPTION
### Detail

- 2가지 종류의 배너 이미지 생성.
- 큰 것, 작은 것으로 재사용 가능.
- 이미지는 `next/image` 를 활용했으며, 이미지를 서버로 부터 받은 배경색을 가지고 있는 `div` 로 감싸주었습니다.

[여기](https://deploy-preview-19--lemondade-storybook.netlify.app)에서 확인해보실 수 있습니다.