### PR TITLE
feat(atom, molecule): shortcut 관련 컴포넌트 작성. (#915)

### DIFF
--- a/src/client/src/components/atoms/ShortcutItem/index.stories.tsx
+++ b/src/client/src/components/atoms/ShortcutItem/index.stories.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import ShortcutItem from ".";
+
+export default {
+	title: "atoms/ShortcutItem",
+	component: ShortcutItem,
+} as ComponentMeta<typeof ShortcutItem>;
+
+const Template: ComponentStory<typeof ShortcutItem> = (args) => (
+	<ShortcutItem {...args}>{args.children}</ShortcutItem>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+	src: "https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjgw/MDAxNjQyMTU5MTU3NjM5.p89ur4TcB7U6IJLE2GJEMtMfYbCgQwjiPkjccxdsJ3kg.DzCb0EY9KMVSa-bbu9mwwPTP7He_inHbnkz6EXB7x2Mg.JPEG/a_3e2d573f7ab04f319d05837caa8ccf2c.jpg?type=m",
+	link: "/",
+	title: "럭키 드로우",
+};

--- a/src/client/src/components/atoms/ShortcutItem/index.stories.tsx
+++ b/src/client/src/components/atoms/ShortcutItem/index.stories.tsx
@@ -14,7 +14,10 @@ const Template: ComponentStory<typeof ShortcutItem> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-	src: "https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjgw/MDAxNjQyMTU5MTU3NjM5.p89ur4TcB7U6IJLE2GJEMtMfYbCgQwjiPkjccxdsJ3kg.DzCb0EY9KMVSa-bbu9mwwPTP7He_inHbnkz6EXB7x2Mg.JPEG/a_3e2d573f7ab04f319d05837caa8ccf2c.jpg?type=m",
+	bigImgSrc:
+		"https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjgw/MDAxNjQyMTU5MTU3NjM5.p89ur4TcB7U6IJLE2GJEMtMfYbCgQwjiPkjccxdsJ3kg.DzCb0EY9KMVSa-bbu9mwwPTP7He_inHbnkz6EXB7x2Mg.JPEG/a_3e2d573f7ab04f319d05837caa8ccf2c.jpg?type=m",
+	smallImgSrc:
+		"https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTc5/MDAxNjQyMTU5MTY0NjAy.meJovZOpmReE3OMln2KOQWNECkhWRpBfkFLL2_gqrm8g.4Z96Qs3T1khnZiv2JLAQFmWkY46j6fION-uXwkJqURIg.JPEG/a_2f4743870ed3490591e19767ee6a8411.jpg",
 	link: "/",
 	title: "럭키 드로우",
 };

--- a/src/client/src/components/atoms/ShortcutItem/index.tsx
+++ b/src/client/src/components/atoms/ShortcutItem/index.tsx
@@ -5,17 +5,18 @@ import Image from "next/image";
 import Link from "next/link";
 
 type ShortcutItemProps = {
-	src: string;
+	bigImgSrc: string;
+	smallImgSrc: string;
 	link: string;
 	title: string;
 };
 
 const ShortcutItem: FunctionComponent<ShortcutItemProps> = (props) => {
-	const { src, link, title } = props;
+	const { bigImgSrc, smallImgSrc, link, title } = props;
 	return (
 		<StyledWrapper>
 			<Link href={`/${link}`}>
-				<StyledImage src={src} alt={src} />
+				<StyledImage src={bigImgSrc} smallSrc={smallImgSrc} alt={bigImgSrc} />
 			</Link>
 			<StyledTitle>{title}</StyledTitle>
 		</StyledWrapper>
@@ -32,9 +33,14 @@ const StyledWrapper = styled.div`
 	cursor: pointer;
 `;
 
-const StyledImage = styled(Image)`
+const StyledImage = styled(Image)<{ smallSrc: string }>`
 	border-radius: 10px;
 	height: 100px;
+	@media screen and (max-width: 1000px) {
+		border-radius: 50%;
+		transition: 0.5s;
+		content: url(${({ smallSrc }) => smallSrc});
+	}
 `;
 
 const StyledTitle = styled.p`

--- a/src/client/src/components/atoms/ShortcutItem/index.tsx
+++ b/src/client/src/components/atoms/ShortcutItem/index.tsx
@@ -1,0 +1,45 @@
+import React, { FunctionComponent } from "react";
+
+import styled from "@emotion/styled";
+import Image from "next/image";
+import Link from "next/link";
+
+type ShortcutItemProps = {
+	src: string;
+	link: string;
+	title: string;
+};
+
+const ShortcutItem: FunctionComponent<ShortcutItemProps> = (props) => {
+	const { src, link, title } = props;
+	return (
+		<StyledWrapper>
+			<Link href={`/${link}`}>
+				<StyledImage src={src} alt={src} />
+			</Link>
+			<StyledTitle>{title}</StyledTitle>
+		</StyledWrapper>
+	);
+};
+
+export default ShortcutItem;
+
+const StyledWrapper = styled.div`
+	text-align: center;
+	width: calc(20% - 15px);
+	display: inline-block;
+	margin: 0 7.5px;
+	cursor: pointer;
+`;
+
+const StyledImage = styled(Image)`
+	border-radius: 10px;
+	height: 100px;
+`;
+
+const StyledTitle = styled.p`
+	font-size: 15px;
+	letter-spacing: -0.15px;
+	color: #333;
+	margin-top: 8px;
+`;

--- a/src/client/src/components/molecules/Shortcuts/index.stories.tsx
+++ b/src/client/src/components/molecules/Shortcuts/index.stories.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import Shortcuts from "./";
+
+export default {
+	title: "molecules/Shortcuts",
+	component: Shortcuts,
+} as ComponentMeta<typeof Shortcuts>;
+
+const Template: ComponentStory<typeof Shortcuts> = (args) => (
+	<Shortcuts {...args}>{args.children}</Shortcuts>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/client/src/components/molecules/Shortcuts/index.tsx
+++ b/src/client/src/components/molecules/Shortcuts/index.tsx
@@ -1,0 +1,58 @@
+import styled from "@emotion/styled";
+import ShortcutItem from "components/atoms/ShortcutItem";
+import React, { FunctionComponent } from "react";
+import { ShortcutItemRes } from "types";
+
+type ShortcutsProps = {
+	items?: ShortcutItemRes[];
+};
+
+const Shortcuts: FunctionComponent<ShortcutsProps> = (props) => {
+	const { items } = props;
+	return (
+		<StyledShortcutWrapper>
+			{items ? (
+				items.map((item) => (
+					<ShortcutItem link={item.link} src={item.image} title={item.title} />
+				))
+			) : (
+				<>
+					<ShortcutItem
+						link={"/"}
+						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfODIg/MDAxNjQyMTU4OTI4NTMw.7_sAnOgUFxUyKVkQgepQp2DWk8pVXpm_xl7LJqAEz1og.7SLCSPjC2IQL4t1trFDzAk3mNvxxYD30jdWVCPIcQmQg.GIF/a_248a7191e7d042e98446f5d2e4fe0c07.gif?type=m"
+						title="프리미엄"
+					/>
+					<ShortcutItem
+						link={"/"}
+						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfNjUg/MDAxNjQyMTU5MDU3NjQ0.6UT2n2TIBXaZrTsANX0jzD5MnAlhGFJoa_1hUk9LuJQg.zgj4FNXPburxIqL7FNfXqoakZwwiYZFZl67ThkiIPxgg.JPEG/a_390f944c3af843598e9e7a887ec1d4ad.jpg?type=m"
+						title="겨울 아우터"
+					/>
+					<ShortcutItem
+						link={"/"}
+						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjE1/MDAxNjQyMTU5MDkzMTA5.jYkIpHR1COueflqCn8Yw55IAHUqU5RldYcwvdOMqfiQg.l21Ywj_7dr7jBm0le5abUnD_Linotl-nFlnHuJ-QK9sg.JPEG/a_3c5bbf01cda2437d9c3d3576f817b22c.jpg?type=m"
+						title="#스타일"
+					/>
+					<ShortcutItem
+						link={"/"}
+						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjgw/MDAxNjQyMTU5MTU3NjM5.p89ur4TcB7U6IJLE2GJEMtMfYbCgQwjiPkjccxdsJ3kg.DzCb0EY9KMVSa-bbu9mwwPTP7He_inHbnkz6EXB7x2Mg.JPEG/a_3e2d573f7ab04f319d05837caa8ccf2c.jpg?type=m"
+						title="럭키 드로우"
+					/>
+					<ShortcutItem
+						link={"/"}
+						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTQz/MDAxNjQyMTU5MjAzMTky.gBmTPr0MuTH3Gb-lzKETZZeR5mL4N0wrNMxPYYsFWPMg.iw9vitAc87EJMgJyYAueUKUMtMW8Vz4lhg_LfMXYUecg.JPEG/a_8118c64019764004be4134ea4c03f1f2.jpg?type=m"
+						title="빠른 배송"
+					/>
+				</>
+			)}
+		</StyledShortcutWrapper>
+	);
+};
+
+export default Shortcuts;
+
+const StyledShortcutWrapper = styled.section`
+	margin: 20px auto 0;
+	padding: 0 32.5px;
+	max-width: 1280px;
+	padding: 0 0 20px;
+`;

--- a/src/client/src/components/molecules/Shortcuts/index.tsx
+++ b/src/client/src/components/molecules/Shortcuts/index.tsx
@@ -13,33 +13,43 @@ const Shortcuts: FunctionComponent<ShortcutsProps> = (props) => {
 		<StyledShortcutWrapper>
 			{items ? (
 				items.map((item) => (
-					<ShortcutItem link={item.link} src={item.image} title={item.title} />
+					<ShortcutItem
+						link={item.link}
+						bigImgSrc={item.bigImg}
+						smallImgSrc={item.smallImg}
+						title={item.title}
+					/>
 				))
 			) : (
 				<>
 					<ShortcutItem
 						link={"/"}
-						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfODIg/MDAxNjQyMTU4OTI4NTMw.7_sAnOgUFxUyKVkQgepQp2DWk8pVXpm_xl7LJqAEz1og.7SLCSPjC2IQL4t1trFDzAk3mNvxxYD30jdWVCPIcQmQg.GIF/a_248a7191e7d042e98446f5d2e4fe0c07.gif?type=m"
+						bigImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfODIg/MDAxNjQyMTU4OTI4NTMw.7_sAnOgUFxUyKVkQgepQp2DWk8pVXpm_xl7LJqAEz1og.7SLCSPjC2IQL4t1trFDzAk3mNvxxYD30jdWVCPIcQmQg.GIF/a_248a7191e7d042e98446f5d2e4fe0c07.gif?type=m"
+						smallImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfNTIg/MDAxNjQyMTU4OTI2MTk1.H8metHzQAOn4bO8PKtj8n1bHEl_Hqrgm5AMdlQqzfg0g.F56SpTs1-xFXWZuv8cBKk7QNlT-EqljWFjQQFO3Gofog.GIF/a_e5864b84421c452f86d0292f134e2beb.gif"
 						title="프리미엄"
 					/>
 					<ShortcutItem
 						link={"/"}
-						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfNjUg/MDAxNjQyMTU5MDU3NjQ0.6UT2n2TIBXaZrTsANX0jzD5MnAlhGFJoa_1hUk9LuJQg.zgj4FNXPburxIqL7FNfXqoakZwwiYZFZl67ThkiIPxgg.JPEG/a_390f944c3af843598e9e7a887ec1d4ad.jpg?type=m"
+						bigImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfNjUg/MDAxNjQyMTU5MDU3NjQ0.6UT2n2TIBXaZrTsANX0jzD5MnAlhGFJoa_1hUk9LuJQg.zgj4FNXPburxIqL7FNfXqoakZwwiYZFZl67ThkiIPxgg.JPEG/a_390f944c3af843598e9e7a887ec1d4ad.jpg?type=m"
+						smallImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTA1/MDAxNjQyMTU5MDU2NDg0.-6iw5D262sfoHyHNjkkz5hfp4Ovn3u_H7zKuvkK5A4og.VY1HNbpQiYeJAb428J6a2CDv3wyUPsifQZO38GOdS-8g.JPEG/a_cb9afbc55d6a46139610fbb315582c8b.jpg"
 						title="겨울 아우터"
 					/>
 					<ShortcutItem
 						link={"/"}
-						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjE1/MDAxNjQyMTU5MDkzMTA5.jYkIpHR1COueflqCn8Yw55IAHUqU5RldYcwvdOMqfiQg.l21Ywj_7dr7jBm0le5abUnD_Linotl-nFlnHuJ-QK9sg.JPEG/a_3c5bbf01cda2437d9c3d3576f817b22c.jpg?type=m"
+						bigImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjE1/MDAxNjQyMTU5MDkzMTA5.jYkIpHR1COueflqCn8Yw55IAHUqU5RldYcwvdOMqfiQg.l21Ywj_7dr7jBm0le5abUnD_Linotl-nFlnHuJ-QK9sg.JPEG/a_3c5bbf01cda2437d9c3d3576f817b22c.jpg?type=m"
+						smallImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTI1/MDAxNjQyMTU5MDg5OTQ4.wb_R_ivuGIcBHgkkheeuggLIEqeepfuFsW9y5vE4E6og.xKR1HnzYOQ89LIb7QZkOAKGAIdBJO7a95gM0NBxra4Ug.JPEG/a_634f051baf754c59bb1f608b63e7a03c.jpg"
 						title="#스타일"
 					/>
 					<ShortcutItem
 						link={"/"}
-						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjgw/MDAxNjQyMTU5MTU3NjM5.p89ur4TcB7U6IJLE2GJEMtMfYbCgQwjiPkjccxdsJ3kg.DzCb0EY9KMVSa-bbu9mwwPTP7He_inHbnkz6EXB7x2Mg.JPEG/a_3e2d573f7ab04f319d05837caa8ccf2c.jpg?type=m"
+						bigImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMjgw/MDAxNjQyMTU5MTU3NjM5.p89ur4TcB7U6IJLE2GJEMtMfYbCgQwjiPkjccxdsJ3kg.DzCb0EY9KMVSa-bbu9mwwPTP7He_inHbnkz6EXB7x2Mg.JPEG/a_3e2d573f7ab04f319d05837caa8ccf2c.jpg?type=m"
+						smallImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTc5/MDAxNjQyMTU5MTY0NjAy.meJovZOpmReE3OMln2KOQWNECkhWRpBfkFLL2_gqrm8g.4Z96Qs3T1khnZiv2JLAQFmWkY46j6fION-uXwkJqURIg.JPEG/a_2f4743870ed3490591e19767ee6a8411.jpg"
 						title="럭키 드로우"
 					/>
 					<ShortcutItem
 						link={"/"}
-						src="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTQz/MDAxNjQyMTU5MjAzMTky.gBmTPr0MuTH3Gb-lzKETZZeR5mL4N0wrNMxPYYsFWPMg.iw9vitAc87EJMgJyYAueUKUMtMW8Vz4lhg_LfMXYUecg.JPEG/a_8118c64019764004be4134ea4c03f1f2.jpg?type=m"
+						bigImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTQz/MDAxNjQyMTU5MjAzMTky.gBmTPr0MuTH3Gb-lzKETZZeR5mL4N0wrNMxPYYsFWPMg.iw9vitAc87EJMgJyYAueUKUMtMW8Vz4lhg_LfMXYUecg.JPEG/a_8118c64019764004be4134ea4c03f1f2.jpg?type=m"
+						smallImgSrc="https://kream-phinf.pstatic.net/MjAyMjAxMTRfMTYz/MDAxNjQyMTU5MjAwMjg2.ew8Fdr7PqkMvzi9MOphqSHy4UvcDn5-GtZzYR4lYmN8g.R5HPRfKcHrNeMmL87gVilTJRZ-HyPrXBeNl5DepofHwg.JPEG/a_5d9605f7d8dc4512bf419672973ca0c1.jpg"
 						title="빠른 배송"
 					/>
 				</>

--- a/src/client/src/types/index.ts
+++ b/src/client/src/types/index.ts
@@ -15,3 +15,9 @@ export interface ProductInfoRes {
 	brandName: string;
 	imageUrls: string;
 }
+
+export interface ShortcutItemRes {
+	link: string;
+	image: string;
+	title: string;
+}

--- a/src/client/src/types/index.ts
+++ b/src/client/src/types/index.ts
@@ -18,6 +18,7 @@ export interface ProductInfoRes {
 
 export interface ShortcutItemRes {
 	link: string;
-	image: string;
+	bigImg: string;
+	smallImg: string;
 	title: string;
 }


### PR DESCRIPTION
### Detail

- 1/15일 기준 업데이트 된 shortcut 컴포넌트 작성.
- 반응형 고려, `media query` 모듈 사용.

[이곳](https://deploy-preview-22--lemondade-storybook.netlify.app/?path=/story/molecules-shortcuts--default)을 누르시면 바로 확인 할 수 있습니다.