### PR TITLE
feat(atom): 가격 정보 관련 컴포넌트 작성. (#914)

### DIFF
--- a/src/client/src/components/atoms/PriceThumbnail/index.stories.tsx
+++ b/src/client/src/components/atoms/PriceThumbnail/index.stories.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import PriceThumbnail from ".";
+
+export default {
+	title: "atoms/PriceThumbnail",
+	component: PriceThumbnail,
+} as ComponentMeta<typeof PriceThumbnail>;
+
+const Template: ComponentStory<typeof PriceThumbnail> = (args) => (
+	<PriceThumbnail {...args}>{args.children}</PriceThumbnail>
+);
+
+export const Home = Template.bind({});
+Home.args = {
+	category: "home",
+	price: 3350000,
+};
+
+export const Shop = Template.bind({});
+Shop.args = {
+	category: "shop",
+	price: 278000,
+};

--- a/src/client/src/components/atoms/PriceThumbnail/index.tsx
+++ b/src/client/src/components/atoms/PriceThumbnail/index.tsx
@@ -1,0 +1,41 @@
+import React, { FunctionComponent } from "react";
+
+import styled from "@emotion/styled";
+
+type PriceThumbnailProps = {
+	category: string;
+	price: number;
+};
+
+const PriceThumbnail: FunctionComponent<PriceThumbnailProps> = (props) => {
+	const { category, price } = props;
+	return (
+		<StyledPriceWrapper category={category}>
+			<StyledPrice>{price.toLocaleString()}원</StyledPrice>
+			<StyledDesc>즉시 구매가</StyledDesc>
+		</StyledPriceWrapper>
+	);
+};
+
+export default PriceThumbnail;
+
+const StyledPriceWrapper = styled.div<{ category: string }>`
+	padding-top: ${({ category }) => (category === "home" ? `7px` : `11px`)};
+	cursor: pointer;
+`;
+
+const StyledPrice = styled.em`
+	display: inline-block;
+	vertical-align: top;
+	line-height: 17px;
+	font-size: 15px;
+	font-weight: 700;
+	letter-spacing: -0.04px;
+	font-style: normal;
+`;
+
+const StyledDesc = styled.div`
+	line-height: 13px;
+	font-size: 11px;
+	color: rgba(34, 34, 34, 0.5);
+`;


### PR DESCRIPTION
### Detail

- 가격 정보 컴포넌트 작성.
- home, shop 화면에서의 가격 정보 font 사이즈가 달라 `category` 로 나누어 개발.

[이곳](https://deploy-preview-23--lemondade-storybook.netlify.app/?path=/story/atoms-pricethumbnail--home)을 눌러 확인 할 수 있습니다.