### PR TITLE
feat(organism): TradeHistory 컴포넌트 생성. (#1110)

### DIFF
--- a/src/client/src/components/atoms/CollectionTitle/index.stories.tsx
+++ b/src/client/src/components/atoms/CollectionTitle/index.stories.tsx
@@ -17,3 +17,8 @@ Default.args = {
 	title: "New In",
 	subTitle: "신규 등록 상품",
 };
+
+export const OnlyTitle = Template.bind({});
+OnlyTitle.args = {
+	title: "구매내역",
+};

--- a/src/client/src/components/atoms/CollectionTitle/index.tsx
+++ b/src/client/src/components/atoms/CollectionTitle/index.tsx
@@ -5,7 +5,7 @@ import colors from "colors/color";
 
 type CollectionTitleProps = {
 	title: string;
-	subTitle: string;
+	subTitle?: string;
 };
 
 const CollectionTitle: FunctionComponent<CollectionTitleProps> = (props) => {
@@ -13,7 +13,7 @@ const CollectionTitle: FunctionComponent<CollectionTitleProps> = (props) => {
 	return (
 		<>
 			<StyledTitle>{title}</StyledTitle>
-			<StyledSubTitle>{subTitle}</StyledSubTitle>
+			{subTitle && <StyledSubTitle>{subTitle}</StyledSubTitle>}
 		</>
 	);
 };

--- a/src/client/src/components/molecules/ProductSmallInfo/index.stories.tsx
+++ b/src/client/src/components/molecules/ProductSmallInfo/index.stories.tsx
@@ -20,3 +20,12 @@ Default.args = {
 	productName: "Nike Dunk Low Retro PRM Halloween",
 	productNameKor: "나이키 덩크 로우 레트로 프리미엄 할로윈",
 };
+
+export const Size = Template.bind({});
+Size.args = {
+	imgSrc:
+		"https://kream-phinf.pstatic.net/MjAyMTA0MTJfNjgg/MDAxNjE4MjA4ODE0MjI3.TrFMsOubBPIX-fyqngJoHiN1h78jPSgISjKBBnRlCakg.QqX73fbXeQ_s69-Ydb4ccVBbQl9OKfiXQL5KUCAH7lcg.JPEG/p_e8c137c6c4de415781c61512464dc384.jpg?type=m",
+	backgroundColor: "crimson",
+	productName: "Nike NRG Solo Swoosh Fleece Hoodie Dark Grey Heather - Asia",
+	size: "L",
+};

--- a/src/client/src/components/molecules/ProductSmallInfo/index.tsx
+++ b/src/client/src/components/molecules/ProductSmallInfo/index.tsx
@@ -7,12 +7,14 @@ type ProductSmallInfoProps = {
 	imgSrc: string;
 	backgroundColor: string;
 	productName: string;
-	productNameKor: string;
+	productNameKor?: string;
+	size?: string;
 	style?: CSSProperties;
 };
 
 const ProductSmallInfo: FunctionComponent<ProductSmallInfoProps> = (props) => {
-	const { imgSrc, backgroundColor, productName, productNameKor, style } = props;
+	const { imgSrc, backgroundColor, productName, productNameKor, style, size } =
+		props;
 
 	return (
 		<ProductArea style={style}>
@@ -21,7 +23,14 @@ const ProductSmallInfo: FunctionComponent<ProductSmallInfoProps> = (props) => {
 			</ProductThumb>
 			<ProductInfoArea>
 				<StyledProductName>{productName}</StyledProductName>
-				<StyledProductNameKor>{productNameKor}</StyledProductNameKor>
+				{size && (
+					<StlyledSize>
+						<StyledSpan>{size}</StyledSpan>
+					</StlyledSize>
+				)}
+				{productNameKor && (
+					<StyledProductNameKor>{productNameKor}</StyledProductNameKor>
+				)}
 			</ProductInfoArea>
 		</ProductArea>
 	);
@@ -45,6 +54,7 @@ const ProductThumb = styled.div<{ backgroundColor: string }>`
 
 const StyledImg = styled(Image)`
 	vertical-align: top;
+	border-radius: 12px;
 `;
 
 const ProductInfoArea = styled.div`
@@ -52,6 +62,20 @@ const ProductInfoArea = styled.div`
 	flex-direction: column;
 	justify-content: center;
 	flex: 1;
+`;
+
+const StlyledSize = styled.p`
+	line-height: 19px;
+	margin-top: 4px;
+`;
+
+const StyledSpan = styled.span`
+	display: inline-block;
+	vertical-align: top;
+	font-size: 14px;
+	font-weight: 700;
+	letter-spacing: -0.5px;
+	color: rgba(34, 34, 34, 0.5);
 `;
 
 const StyledProductName = styled.p`

--- a/src/client/src/components/molecules/TradeHistoryItem/index.stories.tsx
+++ b/src/client/src/components/molecules/TradeHistoryItem/index.stories.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import TradeHistoryItem from ".";
+
+export default {
+	title: "molecules/TradeHistoryItem",
+	component: TradeHistoryItem,
+} as ComponentMeta<typeof TradeHistoryItem>;
+
+const Template: ComponentStory<typeof TradeHistoryItem> = (args) => (
+	<TradeHistoryItem {...args}>{args.children}</TradeHistoryItem>
+);
+
+export const HistoryItem = Template.bind({});
+HistoryItem.args = {
+	imgSrc:
+		"https://kream-phinf.pstatic.net/MjAyMTA0MTJfNjgg/MDAxNjE4MjA4ODE0MjI3.TrFMsOubBPIX-fyqngJoHiN1h78jPSgISjKBBnRlCakg.QqX73fbXeQ_s69-Ydb4ccVBbQl9OKfiXQL5KUCAH7lcg.JPEG/p_e8c137c6c4de415781c61512464dc384.jpg?type=m",
+	backgroundColor: "#ebebeb",
+	productName: "Nike NRG Solo Swoosh Fleece Hoodie Dark Grey Heather - Asia",
+	size: "L",
+	status: 0,
+};
+
+export const HistoryList = Template.bind({});
+HistoryList.args = {
+	imgSrc:
+		"https://kream-phinf.pstatic.net/MjAyMTA0MTJfNjgg/MDAxNjE4MjA4ODE0MjI3.TrFMsOubBPIX-fyqngJoHiN1h78jPSgISjKBBnRlCakg.QqX73fbXeQ_s69-Ydb4ccVBbQl9OKfiXQL5KUCAH7lcg.JPEG/p_e8c137c6c4de415781c61512464dc384.jpg?type=m",
+	backgroundColor: "#ebebeb",
+	productName: "Nike NRG Solo Swoosh Fleece Hoodie Dark Grey Heather - Asia",
+	size: "L",
+	wishedPrice: 70000,
+	expiredDate: "20220224",
+};

--- a/src/client/src/components/molecules/TradeHistoryItem/index.tsx
+++ b/src/client/src/components/molecules/TradeHistoryItem/index.tsx
@@ -71,11 +71,11 @@ const TradeHistoryItemItemWrapper = styled.div`
 	padding: 12px;
 	display: flex;
 	align-items: center;
-	cursor: pointer;
 `;
 
 const HistoryProductArea = styled.div`
 	display: flex;
+	cursor: pointer;
 `;
 
 const HistoryStatusArea = styled.div`
@@ -87,8 +87,8 @@ const HistoryStatusArea = styled.div`
 
 const StatusBlock = styled.div`
 	display: block;
-        margin-left: 10px;
-    width: 134px;
+	margin-left: 25px;
+    // width: 134px;
 }
 `;
 

--- a/src/client/src/components/molecules/TradeHistoryItem/index.tsx
+++ b/src/client/src/components/molecules/TradeHistoryItem/index.tsx
@@ -1,0 +1,99 @@
+import React, { FunctionComponent } from "react";
+
+import styled from "@emotion/styled";
+import ProductSmallInfo from "../ProductSmallInfo";
+
+type TradeHistoryItemProps = {
+	imgSrc: string;
+	backgroundColor: string;
+	productName: string;
+	size: string;
+	status?: number;
+	wishedPrice?: number;
+	expiredDate?: string;
+};
+
+const TradeHistoryItem: FunctionComponent<TradeHistoryItemProps> = (props) => {
+	const {
+		imgSrc,
+		backgroundColor,
+		productName,
+		size,
+		status = -1,
+		wishedPrice,
+		expiredDate,
+	} = props;
+
+	const StatusCode = {
+		0: "입찰 중",
+		1: "진행 중",
+		2: "종료",
+	};
+
+	return (
+		<TradeHistoryItemItemWrapper>
+			<HistoryProductArea>
+				<ProductSmallInfo
+					imgSrc={imgSrc}
+					backgroundColor={backgroundColor}
+					productName={productName}
+					size={size}
+				/>
+			</HistoryProductArea>
+			<HistoryStatusArea>
+				{status >= 0 && (
+					<StatusBlock>
+						<StautsText>{StatusCode[status]}</StautsText>
+					</StatusBlock>
+				)}
+				{wishedPrice && (
+					<StatusBlock>
+						<StautsText>{wishedPrice.toLocaleString()}원</StautsText>
+					</StatusBlock>
+				)}
+				{expiredDate && (
+					<StatusBlock>
+						<StautsText>{`${expiredDate.slice(0, 4)} / ${expiredDate.slice(
+							4,
+							6,
+						)} / ${expiredDate.slice(6)}`}</StautsText>
+					</StatusBlock>
+				)}
+			</HistoryStatusArea>
+		</TradeHistoryItemItemWrapper>
+	);
+};
+
+export default TradeHistoryItem;
+
+const TradeHistoryItemItemWrapper = styled.div`
+	border-bottom: 1px solid #ebebeb;
+	padding: 12px;
+	display: flex;
+	align-items: center;
+	cursor: pointer;
+`;
+
+const HistoryProductArea = styled.div`
+	display: flex;
+`;
+
+const HistoryStatusArea = styled.div`
+	margin-left: auto;
+	display: flex;
+	align-items: center;
+	text-align: right;
+`;
+
+const StatusBlock = styled.div`
+	display: block;
+        margin-left: 10px;
+    width: 134px;
+}
+`;
+
+const StautsText = styled.span`
+	display: block;
+	font-size: 14px;
+	letter-spacing: -0.21px;
+`;

--- a/src/client/src/components/molecules/TradeSummary/index.stories.tsx
+++ b/src/client/src/components/molecules/TradeSummary/index.stories.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import TradeSummary from ".";
+
+export default {
+	title: "molecules/TradeSummary",
+	component: TradeSummary,
+} as ComponentMeta<typeof TradeSummary>;
+
+const Template: ComponentStory<typeof TradeSummary> = (args) => (
+	<TradeSummary {...args}>{args.children}</TradeSummary>
+);
+
+export const Buy = Template.bind({});
+Buy.args = {
+	category: "buy",
+	total: 1,
+	waiting: 2,
+	pending: 0,
+	over: 1,
+};
+
+export const Sell = Template.bind({});
+Sell.args = {
+	category: "sell",
+	total: 1,
+	waiting: 2,
+	pending: 0,
+	over: 1,
+};

--- a/src/client/src/components/molecules/TradeSummary/index.tsx
+++ b/src/client/src/components/molecules/TradeSummary/index.tsx
@@ -1,0 +1,125 @@
+import React, { FunctionComponent } from "react";
+
+import styled from "@emotion/styled";
+import Link from "next/link";
+
+type TradeSummaryProps = {
+	category?: "buy" | "sell";
+	total: number;
+	waiting: number;
+	pending: number;
+	over: number;
+};
+
+const TradeSummary: FunctionComponent<TradeSummaryProps> = (props) => {
+	const { category, total, waiting, pending, over } = props;
+
+	return (
+		<TradeSummaryWrapper>
+			<TabItem>
+				<Link href={`my/buying`}>
+					<StyledA>
+						<StyledDl>
+							<StyledDt>전체</StyledDt>
+							<StyledDdColored category={category}>{total}</StyledDdColored>
+						</StyledDl>
+					</StyledA>
+				</Link>
+			</TabItem>
+			<TabItem>
+				<Link href={`my/buying`}>
+					<StyledA>
+						<StyledDl>
+							<StyledDt>입찰 중</StyledDt>
+							<StyledDd>{waiting}</StyledDd>
+						</StyledDl>
+					</StyledA>
+				</Link>
+			</TabItem>
+			<TabItem>
+				<Link href={`my/buying`}>
+					<StyledA>
+						<StyledDl>
+							<StyledDt>진행 중</StyledDt>
+							<StyledDd>{pending}</StyledDd>
+						</StyledDl>
+					</StyledA>
+				</Link>
+			</TabItem>
+			<TabItem>
+				<Link href={`my/buying`}>
+					<StyledA>
+						<StyledDl>
+							<StyledDt>종료</StyledDt>
+							<StyledDd>{over}</StyledDd>
+						</StyledDl>
+					</StyledA>
+				</Link>
+			</TabItem>
+		</TradeSummaryWrapper>
+	);
+};
+
+export default TradeSummary;
+
+const TradeSummaryWrapper = styled.div`
+	display: table;
+	table-layout: fixed;
+	width: 100%;
+	background-color: #fafafa;
+	border-radius: 12px;
+	margin: 0;
+	padding: 0;
+`;
+
+const TabItem = styled.div`
+	display: table-cell;
+	text-align: center;
+`;
+
+const StyledA = styled.a`
+	position: relative;
+	display: block;
+	padding-top: 18px;
+	height: 96px;
+	&: before {
+		content: "";
+		position: absolute;
+		top: 18px;
+		right: 0;
+		width: 1px;
+		bottom: 18px;
+		background-color: #ebebeb;
+	}
+	&:before last-child {
+		display: none;
+	}
+`;
+
+const StyledDl = styled.dl`
+	margin: 0;
+	padding: 0;
+`;
+
+const StyledDt = styled.dt`
+	font-size: 13px;
+	letter-spacing: -0.07px;
+	color: rgba(34, 34, 34, 0.8);
+`;
+
+const StyledDdColored = styled.dd<{ category: string }>`
+	font-size: 18px;
+	line-height: 20px;
+	letter-spacing: -0.09px;
+	font-weight: 700;
+	margin: 2px 0 auto;
+	color: ${({ category }) => (category === "buy" ? `#f15746` : `#31b46e`)};
+`;
+
+const StyledDd = styled.dd`
+	margin: 2px 0 auto;
+	font-size: 18px;
+	line-height: 20px;
+	letter-spacing: -0.09px;
+	font-weight: 700;
+`;

--- a/src/client/src/components/organisms/TradeHistory/index.stories.tsx
+++ b/src/client/src/components/organisms/TradeHistory/index.stories.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import TradeHistory from ".";
+
+export default {
+	title: "organisms/TradeHistory",
+	component: TradeHistory,
+} as ComponentMeta<typeof TradeHistory>;
+
+const Template: ComponentStory<typeof TradeHistory> = (args) => (
+	<TradeHistory {...args}>{args.children}</TradeHistory>
+);
+
+export const BuyHistory = Template.bind({});
+BuyHistory.args = {
+	category: "buy",
+	total: 2,
+	waiting: 0,
+	pending: 0,
+	over: 3,
+	items: [
+		{
+			imgSrc:
+				"https://kream-phinf.pstatic.net/MjAyMTA0MTJfNjgg/MDAxNjE4MjA4ODE0MjI3.TrFMsOubBPIX-fyqngJoHiN1h78jPSgISjKBBnRlCakg.QqX73fbXeQ_s69-Ydb4ccVBbQl9OKfiXQL5KUCAH7lcg.JPEG/p_e8c137c6c4de415781c61512464dc384.jpg?type=m",
+			backgroundColor: "#ebebeb",
+			productName:
+				"Nike NRG Solo Swoosh Fleece Hoodie Dark Grey Heather - Asia",
+			size: "L",
+			status: 0,
+		},
+		{
+			imgSrc:
+				"https://kream-phinf.pstatic.net/MjAyMTEyMjBfMTA4/MDAxNjM5OTg0MjQxMTYy.F0BGHeY9Lo5okE_K4MrvzWTvO5XQ72TPW7BDhqWZUHUg.0lz1wS4mL94VUWaFzY9RIoiHuARng_qo5Ss7Eir-xk0g.PNG/a_1fef41f2dc8a4c5f9ce69aff036113e3.png",
+			backgroundColor: "rgb(246, 238, 237)",
+			productName:
+				"Nike NRG Solo Swoosh Fleece Hoodie Dark Grey Heather - Asia",
+			size: "270",
+			status: 1,
+		},
+	],
+};
+
+export const SellHistory = Template.bind({});
+SellHistory.args = {
+	category: "sell",
+	total: 2,
+	waiting: 0,
+	pending: 0,
+	over: 3,
+	items: [
+		{
+			imgSrc:
+				"https://kream-phinf.pstatic.net/MjAyMTA0MTJfNjgg/MDAxNjE4MjA4ODE0MjI3.TrFMsOubBPIX-fyqngJoHiN1h78jPSgISjKBBnRlCakg.QqX73fbXeQ_s69-Ydb4ccVBbQl9OKfiXQL5KUCAH7lcg.JPEG/p_e8c137c6c4de415781c61512464dc384.jpg?type=m",
+			backgroundColor: "#ebebeb",
+			productName:
+				"Nike NRG Solo Swoosh Fleece Hoodie Dark Grey Heather - Asia",
+			size: "L",
+			status: 0,
+		},
+		{
+			imgSrc:
+				"https://kream-phinf.pstatic.net/MjAyMTEyMjBfMTA4/MDAxNjM5OTg0MjQxMTYy.F0BGHeY9Lo5okE_K4MrvzWTvO5XQ72TPW7BDhqWZUHUg.0lz1wS4mL94VUWaFzY9RIoiHuARng_qo5Ss7Eir-xk0g.PNG/a_1fef41f2dc8a4c5f9ce69aff036113e3.png",
+			backgroundColor: "rgb(246, 238, 237)",
+			productName:
+				"Nike NRG Solo Swoosh Fleece Hoodie Dark Grey Heather - Asia",
+			size: "270",
+			status: 1,
+		},
+	],
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+	category: "buy",
+	total: 0,
+	waiting: 0,
+	pending: 0,
+	over: 0,
+	items: [],
+};

--- a/src/client/src/components/organisms/TradeHistory/index.tsx
+++ b/src/client/src/components/organisms/TradeHistory/index.tsx
@@ -1,0 +1,112 @@
+import React, { FunctionComponent } from "react";
+
+import CollectionTitle from "components/atoms/CollectionTitle";
+import Icon from "components/atoms/Icon";
+import TradeSummary from "components/molecules/TradeSummary";
+import TradeHistoryItem from "components/molecules/TradeHistoryItem";
+
+import styled from "@emotion/styled";
+import Link from "next/link";
+
+type TradeHistoryProps = {
+	category: "buy" | "sell";
+	total: number;
+	waiting: number;
+	pending: number;
+	over: number;
+	items: any[];
+};
+
+const TradeHistory: FunctionComponent<TradeHistoryProps> = (props) => {
+	const { category, total, waiting, pending, over, items } = props;
+
+	return (
+		<TradeHistoryWrapper>
+			<TradeHistoryTitle>
+				<CollectionTitle
+					title={category === "buy" ? `구매 내역` : `판매 내역`}
+				/>
+				<Link href={category === "buy" ? `/my/buying` : `/my/selling`} passHref>
+					<StyledA>
+						<StyledSpan>더보기</StyledSpan>
+						<Icon
+							name="ChevronRight"
+							style={{
+								width: "15px",
+								height: "15px",
+								color: "rgba(34, 34, 34, 0.5)",
+							}}
+						/>
+					</StyledA>
+				</Link>
+			</TradeHistoryTitle>
+			<RecentTrade>
+				<TradeSummary
+					category={category}
+					total={total}
+					waiting={waiting}
+					pending={pending}
+					over={over}
+				/>
+				{items.length > 0 ? (
+					items.map((item) => (
+						<TradeHistoryItem
+							imgSrc={item.imgSrc}
+							backgroundColor={item.backgroundColor}
+							productName={item.productName}
+							size={item.size}
+							status={item.status}
+						/>
+					))
+				) : (
+					<TradeHistoryEmptySection>
+						<StyledP>거래 내역이 없습니다.</StyledP>
+					</TradeHistoryEmptySection>
+				)}
+			</RecentTrade>
+		</TradeHistoryWrapper>
+	);
+};
+
+export default TradeHistory;
+
+const TradeHistoryWrapper = styled.section``;
+
+const TradeHistoryTitle = styled.div`
+	margin-top: 42px;
+	padding-bottom: 16px;
+	display: flex;
+	max-width: 100%;
+`;
+
+const StyledA = styled.a`
+	margin-top: 3px;
+	margin-left: auto;
+	padding-top: 3px;
+	padding-left: 5px;
+	display: inline-flex;
+	flex-shrink: 0;
+`;
+
+const StyledSpan = styled.span`
+	font-size: 13px;
+	letter-spacing: -0.07px;
+	color: rgba(34, 34, 34, 0.5);
+	padding-right: 10px;
+`;
+
+const RecentTrade = styled.div`
+	margin: 0;
+	padding: 0;
+`;
+
+const TradeHistoryEmptySection = styled.div`
+	padding: 80px 0;
+	text-align: center;
+`;
+
+const StyledP = styled.p`
+	font-size: 13px;
+	letter-spacing: -0.07px;
+	color: rgba(34, 34, 34, 0.5);
+`;


### PR DESCRIPTION
### Detail

- 마이페이지 내부 구매내역 / 판매내역 화면 구성.

- 거래 내역 존재할때

  ![image](https://user-images.githubusercontent.com/52649378/151107851-5727edde-aa12-480c-b06d-e9fb4cbb5e6c.png)

- 거래 내역 비었을때

  ![image](https://user-images.githubusercontent.com/52649378/151107865-8773446d-6a11-4f77-ad23-a3f1caeef33d.png)

- 거래 내역이 존재할때, 존재하지 않을때 컴포넌트 모두 생성.